### PR TITLE
Fix after attribute name

### DIFF
--- a/src/html/tokenizer.ts
+++ b/src/html/tokenizer.ts
@@ -1091,10 +1091,14 @@ export class Tokenizer {
             this.startToken("HTMLTagClose")
             return "DATA"
         }
-
         if (cp === EOF) {
             this.reportParseError("eof-in-tag")
             return "DATA"
+        }
+        if (cp === LEFT_CURLY_BRACKET) {
+            this.returnState = "AFTER_ATTRIBUTE_NAME"
+            this.setStartTokenMark()
+            return "TWIG_EXPRESSION"
         }
 
         this.startToken("HTMLIdentifier")


### PR DESCRIPTION
Necessary for 

```
<sw-something
    required
    {% if VUE3 %}
    ...>
```

This fixes Twig expressions after attribute names with an expression behind.